### PR TITLE
fix ECONFLICT when installing angular

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,5 +22,8 @@
     "angular-mocks": "~1.2.0",
     "angular-scenario": "~1.2.0"
   },
-  "appPath": "app"
+  "appPath": "app",
+  "resolutions": {
+    "angular": "1.2.28"
+  }
 }


### PR DESCRIPTION
bower asked about a specific dependency resolution choice which was
failing the build. Specifying that we want angular 1.2.28 fixes this.

closes #7
